### PR TITLE
Feature/deepspeech 0.6.0

### DIFF
--- a/align/align.py
+++ b/align/align.py
@@ -549,6 +549,7 @@ def main():
     alphabet = Alphabet(alphabet_path)
 
     to_align = []
+    output_graph_path = None
     for audio, tlog, script, aligned in to_prepare:
         if not exists(tlog):
             if output_graph_path is None:
@@ -599,8 +600,8 @@ def main():
                 lm_path = lang_lm_path
                 trie_path = lang_trie_path
 
-            logging.debug('Loading acoustic model from "{}", alphabet from "{}" and language model from "{}"...'
-                          .format(output_graph_path, alphabet_path, lm_path))
+            logging.debug('Loading acoustic model from "{}", alphabet from "{}", trie from "{}" and language model from "{}"...'
+                          .format(output_graph_path, alphabet_path, trie_path, lm_path))
 
             # Run VAD on the input file
             logging.debug('Transcribing VAD segments...')

--- a/align/text.py
+++ b/align/text.py
@@ -160,7 +160,7 @@ def ngrams(s, size):
     if window < 1 or size < 1:
         if window == 0:
             yield s
-        raise StopIteration
+        return
     for i in range(0, window + 1):
         yield s[i:i + size]
 

--- a/align/wavTranscriber.py
+++ b/align/wavTranscriber.py
@@ -20,8 +20,8 @@ def load_model(models, alphabet, lm, trie):
     LM_ALPHA = 1
     LM_BETA = 1.85
 
-    ds = Model(models, N_FEATURES, N_CONTEXT, alphabet, BEAM_WIDTH)
-    ds.enableDecoderWithLM(alphabet, lm, trie, LM_ALPHA, LM_BETA)
+    ds = Model(models, BEAM_WIDTH)
+    ds.enableDecoderWithLM(lm, trie, LM_ALPHA, LM_BETA)
     return ds
 
 
@@ -35,7 +35,7 @@ def stt(ds, audio, fs):
     """
     audio_length = len(audio) * (1 / 16000)
     # Run DeepSpeech
-    output = ds.stt(audio, fs)
+    output = ds.stt(audio)
     return output
 
 

--- a/bin/getmodel.sh
+++ b/bin/getmodel.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-version="0.5.0"
+version="0.6.0"
 dir="deepspeech-${version}-models"
 archive="${dir}.tar.gz"
 

--- a/bin/getmodel.sh
+++ b/bin/getmodel.sh
@@ -12,3 +12,6 @@ fi
 
 tar -xzvf $archive
 mv $dir en
+
+wget "https://raw.githubusercontent.com/mozilla/DeepSpeech/master/data/alphabet.txt"
+mv alphabet.txt en

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 sox
-deepspeech
+deepspeech==0.6.0
 webrtcvad
 tqdm
 textdistance


### PR DESCRIPTION
Tested with the following params:
```
--output-max-cer 15 --loglevel 10 --audio data/test1/audio.wav --script data/test1/transcript.txt --aligned data/test1/aligned.json --tlog data/test1/log.txt --stt-model-dir models/en/deepspeech-0.6.0-models --alphabet models/en/alphabet.txt --stt-no-own-lm
```
After fix for missing alphabet.txt I tested with the following params:
```
--output-max-cer 15 --loglevel 10 --audio data/test1/audio.wav --script data/test1/transcript.txt --aligned data/test1/aligned.json --tlog data/test1/log.txt --stt-no-own-lm
```
Still need to figure out how to solve the following error when running without stt-no-own-lm:
```
Error: Trie file version mismatch (4 instead of expected 5). Update your trie file.
```
Got passed this error by using v0.6.0 of the native client from GitHub extracted into dependencies/deepspeech. taskcluster.py is supposed to fix this but taskcluster.net seems deprecated.