### PR TITLE
Fix KenLM model generation on smaller texts

### DIFF
--- a/align/align.py
+++ b/align/align.py
@@ -571,6 +571,7 @@ def main():
                 if not path.exists(arpa_path):
                     subprocess.check_call([
                         kenlm_path + '/lmplz',
+                        '--discount_fallback',
                         '--text',
                         clean_text_path,
                         '--arpa',


### PR DESCRIPTION
Add --discount-fallback argument to lmplz, which was necessary when generating a language model for a smaller transcription. This option enables a fallback, and shouldn't affect anything except KenLM models that would've otherwise errored out.